### PR TITLE
Added changes for case-insensitive language search

### DIFF
--- a/src/components/table/Table.js
+++ b/src/components/table/Table.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 
 import { TableHeaderColumn, BootstrapTable } from 'react-bootstrap-table';
 
@@ -25,7 +25,7 @@ export default class Table extends Component {
 
   render() {
     return (
-      <React.Fragment>
+      <Fragment>
         <BootstrapTable
           ref="table"
           data={this.state.data}
@@ -60,7 +60,7 @@ export default class Table extends Component {
             filter={{
               type: 'TextFilter',
               placeholder: 'Language?',
-              condition: 'eq'
+              condition: 'like'
             }}
             dataFormat={languageFormatter}
           >
@@ -97,7 +97,7 @@ export default class Table extends Component {
           </TableHeaderColumn>
         </BootstrapTable>
         )}
-      </React.Fragment>
+      </Fragment>
     );
   }
 }


### PR DESCRIPTION
- Used 'like' filter instead of exact 'eq'.
- Using this would cause search for 'c' showing
  languages such as C++, C#, Obj-C
- This should be helpful for now (search for html instead of HTMl)
- Even though this works for most cases, consider
  this as a temp fix until changes like [remote-filtering] are put in.

Ref <remote-filtering>:
https://github.com/AllenFang/react-bootstrap-table/blob/master/examples/js/remote/remote-store-filtering.js#L67